### PR TITLE
Add project tracker plan for RAG platform

### DIFF
--- a/project_tracker_plan.md
+++ b/project_tracker_plan.md
@@ -1,0 +1,91 @@
+# RAG Platform Delivery Backlog Structure
+
+This document provides a ready-to-import outline for configuring the project tracker (e.g., Jira) when direct automation is not available. It mirrors the backlog hierarchy, sprint alignment, and acceptance criteria needed for Epic 1.
+
+## Initiative
+- **Name:** RAG Platform Delivery
+- **Description:** Deliver an end-to-end Retrieval-Augmented Generation platform that supports authenticated chat, curated document ingestion, and analytics-driven iteration.
+- **Sprint Alignment Notes:**
+  - Sprint 1: Establish foundational backend/frontend scaffolding and CI.
+  - Sprint 2: Deliver document ingestion pipeline and core chat features.
+  - Sprint 3: Integrate analytics, feedback loops, and release readiness tasks.
+
+## Epics
+
+### 1. Backend Platform
+- **Goal:** Provide authenticated access, session management, and FastAPI proxy endpoints.
+- **Stories:**
+  1. **Authentication & Session Setup**  
+     - *Description:* Configure user login, secure session cookies, and CSRF protection.  
+     - *Acceptance Criteria:* Users can log in/out, sessions persist across requests, and unauthenticated calls are rejected.  
+  2. **FastAPI Proxy Gateway**  
+     - *Description:* Route chat and retrieval requests through the backend to the FastAPI RAG service.  
+     - *Acceptance Criteria:* Authenticated requests reach FastAPI with session context; errors are surfaced consistently.  
+  3. **Backend CI/CD Pipeline**  
+     - *Description:* Implement automated tests and deployment pipeline for backend services.  
+     - *Acceptance Criteria:* Pull requests run tests automatically and deployments require passing checks.
+
+### 2. Frontend Experience
+- **Goal:** Create a React-based UI for chat, document previews, and saved answers.  
+- **Stories:**
+  1. **Chat Interface MVP**  
+     - *Description:* Implement chat window with streaming responses and message history.  
+     - *Acceptance Criteria:* Users can send/receive messages with typing indicators.  
+  2. **Document Preview Pane**  
+     - *Description:* Display retrieved document snippets with metadata.  
+     - *Acceptance Criteria:* Selecting a message reveals associated document snippets.  
+  3. **Saved Answers Management**  
+     - *Description:* Allow users to save, tag, and revisit answers.  
+     - *Acceptance Criteria:* Saved answers persist across sessions and are searchable.
+
+### 3. Document Pipeline
+- **Goal:** Build ingestion scripts, metadata enrichment, and embedding jobs.  
+- **Stories:**
+  1. **Source Ingestion Script**  
+     - *Description:* Connect to primary repositories (S3, GDrive) and pull documents into staging.  
+     - *Acceptance Criteria:* Scheduled runs ingest new/updated documents with logging.  
+  2. **Metadata Enrichment Module**  
+     - *Description:* Extract metadata (author, tags) and chunk documents for embedding.  
+     - *Acceptance Criteria:* Enriched records include required fields and chunk lengths meet thresholds.  
+  3. **Embedding Generation Job**  
+     - *Description:* Generate embeddings using configured model and push to vector store.  
+     - *Acceptance Criteria:* Embeddings are generated within SLA and stored with document references.
+
+### 4. Analytics & Observability
+- **Goal:** Capture usage metrics, feedback, and system health insights.  
+- **Stories:**
+  1. **Analytics Schema Definition**  
+     - *Description:* Design database tables for query logs, latency, and user feedback.  
+     - *Acceptance Criteria:* Schema documented and migrations available.  
+  2. **Event Instrumentation**  
+     - *Description:* Emit structured analytics events from backend and frontend.  
+     - *Acceptance Criteria:* Events are captured with correlation IDs and can be queried.  
+  3. **Relevance Dashboard**  
+     - *Description:* Configure dashboards highlighting usage trends and feedback outcomes.  
+     - *Acceptance Criteria:* Stakeholders can view dashboards with up-to-date metrics.
+
+### 5. Launch Enablement
+- **Goal:** Ensure documentation, runbooks, and readiness for launch.  
+- **Stories:**
+  1. **Runbook Creation**  
+     - *Description:* Document operational procedures and on-call guides.  
+     - *Acceptance Criteria:* Runbook covers deployments, rollbacks, and incident response.  
+  2. **User Training Materials**  
+     - *Description:* Provide onboarding documentation for end users.  
+     - *Acceptance Criteria:* Training decks/videos cover core workflows and FAQs.  
+  3. **Go-Live Checklist**  
+     - *Description:* Compile checklist including monitoring, QA sign-off, and stakeholder approvals.  
+     - *Acceptance Criteria:* Checklist is signed off before launch.
+
+## Sprint Board Configuration
+- **Swimlanes:** Group by epic to visualize progress across pillars.  
+- **Columns:** Backlog → Ready → In Progress → In Review → Done.  
+- **Estimations:** Apply story points during grooming; target balanced load per sprint.  
+- **Definition of Ready:** Requirements, dependencies, and acceptance criteria documented.  
+- **Definition of Done:** Code merged, tests passing, documentation updated, and analytics hooks instrumented where applicable.
+
+## Next Steps
+1. Import initiative/epic/story structure into the project tracker manually or via CSV.  
+2. Assign owners and set sprint targets per epic.  
+3. Review acceptance criteria with stakeholders before sprint planning.  
+4. Iterate on backlog based on user feedback and analytics insights.


### PR DESCRIPTION
## Summary
- add a backlog outline document that captures the initiative, epics, stories, and sprint board guidance for the RAG platform delivery effort
- document next steps so the structure can be imported manually into a project tracker

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68f8318fea58832fa24fbb1a2386a8d4