### PR TITLE
Add knowledge RAG product plan and retrieval improvements

### DIFF
--- a/docs/analytics_requirements.md
+++ b/docs/analytics_requirements.md
@@ -1,0 +1,48 @@
+# Analytics & Observability Requirements
+
+## Objectives
+- Understand how users search, which documents drive successful answers, and where the assistant underperforms.
+- Provide compliance teams with full lineage of responses for audits.
+- Enable continuous improvement of retrieval and ranking via feedback loops.
+
+## Data Capture Matrix
+| Event | Trigger | Payload Fields | Destination |
+| --- | --- | --- | --- |
+| `query_issued` | User submits prompt | `session_id`, `message_id`, `user_id`, `prompt`, `filters`, `timestamp`, `client_app` | Event stream (Kafka topic `rag.events`) + OLAP warehouse |
+| `response_stream_started` | Backend begins streaming answer | `session_id`, `message_id`, `rag_request_id`, `model_version`, `latency_ms`, `retriever_k` | Metrics service (Prometheus) |
+| `document_retrieved` | Each document returned from retriever | `session_id`, `message_id`, `document_id`, `chunk_id`, `score`, `preview`, `metadata`, `rank` | Feature store + warehouse |
+| `answer_completed` | Assistant finishes response | `session_id`, `message_id`, `tokens_prompt`, `tokens_completion`, `latency_ms`, `confidence` | Warehouse + monitoring |
+| `clarification_shown` | Clarifying question surfaced | `session_id`, `message_id`, `clarification_id`, `options` | Warehouse |
+| `clarification_selected` | User picks clarification | `session_id`, `message_id`, `clarification_id`, `selected_option` | Warehouse |
+| `saved_answer_created` | User bookmarks response | `saved_answer_id`, `session_id`, `message_id`, `tags`, `notes_length` | Warehouse |
+| `feedback_submitted` | Thumbs up/down or free-text feedback | `feedback_id`, `session_id`, `message_id`, `document_ids`, `rating`, `comment`, `submitted_by`, `timestamp` | Warehouse + alerting pipeline |
+| `ingestion_job_completed` | Document pipeline finishes | `job_id`, `source_type`, `documents_processed`, `chunks_processed`, `errors`, `duration_ms` | Monitoring + warehouse |
+
+## Storage & Processing
+- **Event streaming**: Kafka (topic partitioned by `tenant_id`), 7-day retention; consumers write to warehouse (Snowflake/BigQuery) and feature store.
+- **Metrics**: Prometheus counters/histograms for latency, throughput, error rates; Grafana dashboards for live monitoring.
+- **Warehouse schema**: Star schema with fact tables (`fact_queries`, `fact_documents`, `fact_feedback`) and dimension tables (`dim_user`, `dim_document`, `dim_session`).
+- **PII Handling**: Hash `user_id` and avoid storing raw prompts in lower environments; mask sensitive tokens via DLP.
+
+## Relevance Feedback Loop
+1. Store thumbs up/down plus granular feedback on individual documents.
+2. Batch process nightly to compute document success rate, model confidence calibration, and filter usage patterns.
+3. Feed aggregated metrics into re-ranking model training set and ingestion prioritization.
+4. Provide dashboards for SMEs to review low-performing documents and submit updates.
+
+## Audit & Compliance Reporting
+- Generate weekly reports summarizing top regulatory queries, documents cited, and associated security tiers.
+- Maintain immutable log of responses with metadata to satisfy GDPR/CCPA subject access requests.
+- Implement retention policy: raw events 13 months, aggregated metrics 36 months, with region-specific overrides.
+
+## Alerting & SLOs
+- **SLO**: 99% of responses delivered < 5s; alert if rolling 5-min latency > threshold.
+- Alert on ingestion failure rate > 2% per source in 1 hour.
+- Alert when feedback negative ratio exceeds 15% for any product line within 24h.
+- Trigger page if streaming errors > 5 per minute per region.
+
+## Instrumentation Checklist
+- Frontend logs interactions via Segment SDK (batched, sampling configurable).
+- Backend middleware injects `session_id` and `rag_request_id` into structured logs.
+- Python RAG service exports OpenTelemetry traces (`retrieve`, `generate`, `rerank` spans) with propagation from frontend request.
+- All services share correlation IDs to stitch full journey across systems.

--- a/docs/backend_architecture.md
+++ b/docs/backend_architecture.md
@@ -1,0 +1,65 @@
+# Backend Architecture & Routes
+
+## Overview
+The backend acts as an orchestration layer between client applications, the Python RAG service (`src/rag`), and upstream systems (document storage, auth, analytics). It should expose stable REST + streaming APIs, enforce security, and manage session context.
+
+## Recommended Stack
+- **Framework**: Node.js (NestJS) or Django REST Framework. Below outlines a Node/NestJS reference, with notes for Django parity.
+- **Data stores**: Postgres for metadata/catalog, Redis for session cache & rate limiting, S3/GCS for document blobs.
+- **Integration**: gRPC or REST proxy to Python RAG worker, message bus (Kafka) for ingestion triggers.
+
+## Service Modules
+1. **Auth & Identity** – integrates with SSO provider (OIDC). Injects user claims (role, region, business unit, security tier) into requests.
+2. **Session Manager** – persists conversation sessions, message timeline, clarifications, and saved answers. Maintains TTL-based cache in Redis for active sessions.
+3. **Document Orchestrator** – handles ingestion webhooks, manual uploads, and monitors pipeline jobs.
+4. **RAG Proxy** – normalizes requests to Python RAG service, handles streaming responses, attaches metadata filters.
+5. **Feedback & Analytics** – logs interactions, collects relevance feedback, exposes metrics endpoints.
+
+## Route Blueprint (Node/NestJS style)
+| Method | Path | Module | Description |
+| --- | --- | --- | --- |
+| `POST` | `/sessions` | Session Manager | Create new conversation session with inferred defaults (filters, persona). |
+| `GET` | `/sessions/:sessionId` | Session Manager | Retrieve session metadata, participants, active filters. |
+| `POST` | `/sessions/:sessionId/messages` | RAG Proxy | Forward user prompt and filters, stream assistant response + documents. |
+| `GET` | `/sessions/:sessionId/messages` | Session Manager | Paginated history with citations & feedback state. |
+| `POST` | `/sessions/:sessionId/clarifications` | RAG Proxy | Submit clarifying choice referencing parent message. |
+| `POST` | `/sessions/:sessionId/saved-answers` | Session Manager | Bookmark a message and associated documents. |
+| `GET` | `/saved-answers` | Session Manager | List saved answers with filters (owner, tag, session). |
+| `DELETE` | `/saved-answers/:id` | Session Manager | Remove saved answer. |
+| `POST` | `/documents/ingest` | Document Orchestrator | Trigger ingestion workflow (manual upload or connector sync). |
+| `POST` | `/documents/ingest/webhook` | Document Orchestrator | Receive connector callbacks with payload metadata. |
+| `GET` | `/documents/:documentId` | Document Orchestrator | Fetch document metadata, preview, audit trail. |
+| `POST` | `/feedback` | Feedback & Analytics | Submit relevance feedback tied to message and document IDs. |
+| `GET` | `/health` | Platform | Health/liveness probe exposing dependencies. |
+
+### Streaming Implementation
+- Expose `/sessions/:id/messages/stream` using Server-Sent Events (NestJS `@Sse` controller or Django Channels) to deliver incremental tokens.
+- Attach metadata events for each retrieved document (`doc-preview`, `doc-update`).
+
+### RAG Proxy Responsibilities
+1. Translate REST payload into `RetrieveRequest` for Python service, injecting metadata filters derived from user claims.
+2. Maintain circuit breaker & retries around Python worker; degrade gracefully to fallback search.
+3. Normalize document previews (title, snippet, metadata) before returning to client.
+
+## Document Ingestion Triggers
+- **Manual upload**: `/documents/ingest` accepts multipart file, metadata JSON; enqueues job to ingestion pipeline (e.g., using BullMQ or Celery).
+- **Scheduled sync**: Cron job hits external connectors, pushes delta payloads into queue.
+- **Webhook**: `/documents/ingest/webhook` validates signature, maps payload to canonical schema, writes to staging table, and notifies pipeline service.
+
+## Django Parity Notes
+- Use Django REST Framework ViewSets with routers mirroring above endpoints.
+- Streaming via Django Channels or HttpResponse `streaming_content` generator for SSE.
+- Background jobs handled with Celery + Django-Q for ingestion tasks.
+- Authentication using django-allauth or social-auth with JWT issuance; apply DRF permissions for `security_tier` filtering.
+
+## Session Persistence Model
+- `sessions` table: `session_id`, `user_id`, `created_at`, `active_filters (JSONB)`, `persona`.
+- `messages` table: `message_id`, `session_id`, `role`, `content`, `citations (JSONB)`, `documents (JSONB)`, `created_at`, `model_latency_ms`.
+- `clarifications` table: `clarification_id`, `message_id`, `prompt`, `selected_option`.
+- `saved_answers` table: `id`, `session_id`, `message_id`, `tags`, `notes`, `created_by`, `created_at`.
+
+## Security & Compliance Considerations
+- Enforce attribute-based access control using `security_tier` & `region` claims on every request.
+- Rate-limit prompts per user & per session using Redis token bucket.
+- Audit logging for ingestion events and message access.
+- Data retention policy configurable per region; soft-delete sessions older than N days while retaining analytics aggregates.

--- a/docs/product_brief.md
+++ b/docs/product_brief.md
@@ -1,0 +1,86 @@
+# Product Brief: Domain Knowledge Retrieval Platform
+
+## Vision
+Empower internal teams with a conversational assistant that answers questions with curated corporate knowledge while maintaining compliance and traceability across regional business units.
+
+## Target Users
+- **Customer support specialists** resolving policy and troubleshooting inquiries.
+- **Account managers** preparing renewal proposals and executive summaries.
+- **Solutions engineers** validating technical feasibility and implementation patterns.
+- **Regional compliance leads** ensuring responses align with local regulations.
+
+## Domain Document Catalogue
+
+### Canonical Schema
+| Field | Type | Description |
+| --- | --- | --- |
+| `document_id` | UUID | Stable identifier for the source document. |
+| `source_type` | Enum (`playbook`, `policy`, `faq`, `runbook`, `case-study`) | High-level categorization for routing and compliance. |
+| `title` | String | Human-readable title surfaced in search results. |
+| `summary` | Text | Short synopsis used for previews. |
+| `business_unit` | Enum | Team or organization owner (e.g., `support`, `sales`, `compliance`). |
+| `product_line` | Enum | Product area or service that the document supports. |
+| `region` | Enum (`global`, `amer`, `emea`, `apac`) | Regional applicability for filtering. |
+| `language` | ISO-639-1 code | Primary language of the content. |
+| `lifecycle_stage` | Enum (`draft`, `active`, `deprecated`) | Indicates freshness and retirement. |
+| `effective_date` | Date | Start date for document validity. |
+| `expires_at` | Date? | Optional end-of-life date. |
+| `tags` | Array[String] | Folksonomy tags curated by SMEs. |
+| `security_tier` | Enum (`internal`, `confidential`, `restricted`) | Access guardrails used by policy engine. |
+| `author_id` | UUID | Owner for routing feedback. |
+| `source_url` | URL | Link back to original system of record. |
+| `version` | Integer | Incremented on each ingestion. |
+| `checksum` | String | Hash used to detect content drift. |
+| `blob_path` | String | Pointer to storage bucket object. |
+
+### Chunk Schema (Embeddable Units)
+| Field | Type | Description |
+| --- | --- | --- |
+| `chunk_id` | UUID | Unique chunk identifier. |
+| `document_id` | UUID | Foreign key to canonical document. |
+| `chunk_index` | Integer | Order of chunk within document. |
+| `content` | Text | Cleaned text body used for retrieval. |
+| `token_count` | Integer | Token length for embedding/backoff heuristics. |
+| `embedding` | Vector[float] | Dense vector stored in FAISS or compatible index. |
+| `metadata` | JSON | Flattened subset of document fields plus ingestion timestamp. |
+
+## Ingestion Pipeline
+1. **Source registration** – connectors for CMS exports (S3 drop), Confluence API, CRM attachments, and manual SME uploads.
+2. **Fetch & normalize** – convert to markdown/plaintext, strip boilerplate, detect language, and classify document type.
+3. **Metadata enrichment** – map ownership, region, lifecycle, security tier, and auto-tag using zero-shot classifier.
+4. **Chunking** – recursive character text splitter (~750 tokens, 200 overlap) with adaptive chunking for tables and FAQs.
+5. **Quality gates** – validation for required metadata, PII redaction, policy compliance, and deduplication via checksum.
+6. **Embedding generation** – encode using `sentence-transformers/all-MiniLM-L6-v2`; store embeddings and metadata in vector store plus Postgres catalog.
+7. **Publishing** – trigger vector index upsert, search cache warm-up, and Slack notifications for reviewers.
+8. **Observability hooks** – emit ingestion metrics (`documents_processed`, `chunk_failures`, `embedding_latency`).
+
+## Embedding Strategy
+- **Primary model**: `sentence-transformers/all-MiniLM-L6-v2` for balanced latency/quality.
+- **Specialized tuning**: fine-tune on labeled Q&A pairs for compliance-critical content; maintain experiments via MLflow.
+- **Hybrid retrieval**: store BM25 indices (Elastic) alongside FAISS for lexical fallback on regulatory keywords.
+- **Versioning**: maintain embedding `model_version` in metadata; re-embed delta documents asynchronously.
+- **Security**: embeddings stored in dedicated namespace with row-level security keyed by `security_tier` and `region`.
+
+## Must-Have User Journeys
+1. **Answer customer question during live chat**
+   - Trigger: Support specialist opens the assistant within the CRM sidebar.
+   - Flow: Ask natural language question → filter by product line & region automatically → review top 3 answers with citations → insert curated response into chat.
+   - Success metrics: reduced handle time, higher first-contact resolution.
+2. **Prepare renewal brief**
+   - Trigger: Account manager queries for latest ROI stories and compliance notes.
+   - Flow: Search "renewal playbook" → clarify segment (enterprise vs SMB) → view saved answers and export summary deck.
+   - Success metrics: time-to-insight, attach rate of cross-sell playbooks.
+3. **Validate implementation feasibility**
+   - Trigger: Solutions engineer evaluating custom feature request.
+   - Flow: Ask for architecture precedent → apply metadata filters (`product_line`, `security_tier`) → inspect document previews → bookmark relevant designs.
+   - Success metrics: reduced escalation volume, accuracy of feasibility assessments.
+4. **Audit regulatory response**
+   - Trigger: Compliance lead reviews assistant history for GDPR queries.
+   - Flow: Filter conversations by region & lifecycle stage → inspect answer lineage with source metadata → provide feedback marking authoritative sources.
+   - Success metrics: audit completeness, number of flagged inaccurate answers.
+
+## Risks & Mitigations
+- **Stale content** – enforce lifecycle metadata and automated re-ingestion alerts.
+- **Access control gaps** – integrate document `security_tier` with IAM scopes and pre-filter retrieval.
+- **Explainability** – include document previews, source URLs, and metadata in every answer for trust.
+- **Adoption** – embed must-have journeys into CRM/Slack workflows with minimal context switching.

--- a/docs/react_ui_flows.md
+++ b/docs/react_ui_flows.md
@@ -1,0 +1,87 @@
+# React UI Flows & API Contracts
+
+## Design Principles
+- **Assistive first**: inline clarifications and source context reduce trial-and-error.
+- **Progressive disclosure**: show concise previews by default, expand on demand.
+- **Session aware**: persistent timeline for follow-up questions and saved answers.
+- **Trustworthy**: every response ties to citations, metadata, and feedback controls.
+
+## Conversational Search Flow
+1. **Entry point** – User opens the "Ask" panel from CRM sidebar or standalone web app.
+2. **Prompt composer** – Rich text box with suggested prompts, metadata filter chips (product, region, security tier) pulled from profile defaults.
+3. **Response stream** – Model reply rendered with inline citations, collapse/expand previews, and "Save" / "Improve" actions.
+4. **Follow-up controls** – Quick reply buttons ("Drill into policy", "Show implementation guide"), clarifying questions surfaced from backend suggestions.
+5. **Conversation timeline** – Sticky left rail summarizing previous questions, enabling jump-back and sharing.
+
+### Required Components
+- `<ConversationLayout>` – orchestrates header (session info), main panel (messages), right rail (document viewer).
+- `<MessageBubble>` – supports markdown rendering, inline code, citations, and status states (thinking, streaming, complete).
+- `<FilterBar>` – multi-select chips bound to metadata facets; surfaces applied filters.
+- `<DocumentPreviewDrawer>` – slides over to show full source with metadata.
+- `<FeedbackBar>` – thumbs up/down, free-text comment, and "mark as authoritative" toggle for SMEs.
+
+### API Contracts
+| Endpoint | Method | Payload | Response |
+| --- | --- | --- | --- |
+| `/api/sessions/:sessionId/messages` | `POST` | `{ prompt: string, filters?: MetadataFilter, context?: MessageRef[] }` | `{ messageId, answer, citations: Citation[], documents: PreviewDocument[], clarifications?: ClarificationPrompt[] }` |
+| `/api/sessions/:sessionId/messages` | `GET` | `?cursor=<timestamp>` | `{ messages: Message[], nextCursor? }` |
+| `/api/metadata/facets` | `GET` | `?sessionId=...` | `{ facets: FacetDefinition[] }` |
+| `/api/documents/:documentId` | `GET` | `?chunkId=` | `{ documentId, title, metadata, content, auditTrail }` |
+
+`MetadataFilter` example:
+```ts
+{
+  productLine?: string[];
+  region?: ("global" | "amer" | "emea" | "apac")[];
+  securityTier?: ("internal" | "confidential" | "restricted")[];
+  lifecycleStage?: ("draft" | "active" | "deprecated")[];
+}
+```
+
+`PreviewDocument` example:
+```ts
+{
+  documentId: string;
+  chunkId: string;
+  title: string;
+  preview: string;
+  score: number;
+  metadata: Record<string, string | string[]>;
+  sourceUrl?: string;
+}
+```
+
+## Clarification Flow
+1. Backend detects ambiguous query (low confidence or multiple intents).
+2. UI surfaces `<ClarificationCard>` under the assistant message with suggested follow-up questions.
+3. User selects one suggestion or writes custom clarifying prompt; conversation timeline groups follow-up under parent.
+4. On selection, new request includes `context` referencing original message IDs for disambiguation.
+
+### Additional API Contract
+| Endpoint | Method | Payload | Response |
+| --- | --- | --- | --- |
+| `/api/sessions/:sessionId/clarifications` | `POST` | `{ messageId, clarificationId }` | `{ messageId: string, answer: string, documents: PreviewDocument[] }` |
+
+## Saved Answers Flow
+1. User clicks "Save" on a message to bookmark response and associated documents.
+2. Modal prompts for tags (`case`, `customer`, `topic`) and optional notes.
+3. Saved answer appears in `<SavedAnswersPanel>` accessible from global nav, grouped by session or tag.
+4. Users can export to PDF/email or share link with permissions enforced via backend.
+
+### API Contracts
+| Endpoint | Method | Payload | Response |
+| --- | --- | --- | --- |
+| `/api/sessions/:sessionId/saved-answers` | `POST` | `{ messageId, tags: string[], notes?: string }` | `{ savedAnswerId, savedAt }` |
+| `/api/saved-answers` | `GET` | `?tag=&ownerId=` | `{ savedAnswers: SavedAnswerSummary[] }` |
+| `/api/saved-answers/:savedAnswerId` | `GET` | - | `{ message, documents, metadata, notes }` |
+| `/api/saved-answers/:savedAnswerId` | `DELETE` | - | `{ deleted: true }` |
+
+## State Management & Data Layer
+- Use **React Query** for request caching and optimistic updates on feedback or saved answers.
+- Maintain conversation state in context provider (`ConversationProvider`) with reducer actions (`sendMessage`, `applyFilters`, `saveAnswer`).
+- Stream responses via Server-Sent Events or WebSocket; update message state incrementally to enable streaming UI.
+
+## Error & Empty States
+- Show inline error banner with retry for network or backend failures.
+- Provide "No documents found" state with quick actions (clear filters, broaden query).
+- Escalate repeated failures by offering "Hand off to human" CTA linking to live support.

--- a/src/rag/tools.py
+++ b/src/rag/tools.py
@@ -1,26 +1,128 @@
 from __future__ import annotations
 
+from dataclasses import dataclass
+from typing import Any, Dict, Iterable, List, Optional, Tuple
+
 from langchain_core.tools import tool
+
 from rag.vector import vector_store as _vector_store
+
 
 def _store():
     """Return the actual vector store instance (handles lru_cache factory or plain object)."""
     return _vector_store() if callable(_vector_store) else _vector_store
 
-def _retrieve_impl(query: str):
+
+@dataclass
+class RetrievedDocument:
+    """Serializable representation of a retrieved document chunk."""
+
+    document_id: Optional[str]
+    chunk_id: Optional[str]
+    title: Optional[str]
+    preview: str
+    score: Optional[float]
+    metadata: Dict[str, Any]
+    content: Optional[str] = None
+
+
+def _make_preview(text: str, preview_chars: int) -> str:
+    if len(text) <= preview_chars:
+        return text
+    truncated = text[:preview_chars].rsplit(" ", 1)[0]
+    return f"{truncated.strip()}…"
+
+
+def _similarity_with_scores(store, query: str, *, k: int, filters: Optional[Dict[str, Any]]):
+    search_kwargs: Dict[str, Any] = {"k": k}
+    if filters:
+        search_kwargs["filter"] = filters
+
+    if hasattr(store, "similarity_search_with_relevance_scores"):
+        return store.similarity_search_with_relevance_scores(query, **search_kwargs)
+    if hasattr(store, "similarity_search_with_score"):
+        return store.similarity_search_with_score(query, **search_kwargs)
+
+    docs = store.similarity_search(query, **search_kwargs)
+    return [(doc, None) for doc in docs]
+
+
+def _serialize(documents: Iterable[RetrievedDocument]) -> str:
+    parts: List[str] = []
+    for idx, doc in enumerate(documents, start=1):
+        parts.append(
+            "\n".join(
+                [
+                    f"Result {idx}",
+                    f"Document ID: {doc.document_id}",
+                    f"Chunk ID: {doc.chunk_id}",
+                    f"Title: {doc.title}",
+                    f"Score: {doc.score}",
+                    f"Preview: {doc.preview}",
+                    f"Metadata: {doc.metadata}",
+                ]
+            )
+        )
+    return "\n\n".join(parts)
+
+
+def _retrieve_impl(
+    query: str,
+    *,
+    filters: Optional[Dict[str, Any]] = None,
+    limit: int = 4,
+    preview_chars: int = 280,
+    include_content: bool = False,
+) -> Tuple[str, List[RetrievedDocument]]:
     store = _store()
-    retriever = store.as_retriever(search_kwargs={"k": 4})
-    docs = retriever.invoke(query)
-    serialized = "\n\n".join(
-        f"Source: {getattr(d, 'metadata', {})}\nContent: {getattr(d, 'page_content', '')}"
-        for d in docs
-    )
-    return serialized, docs
+    results_with_scores = _similarity_with_scores(store, query, k=limit, filters=filters)
+
+    structured: List[RetrievedDocument] = []
+    for doc, score in results_with_scores:
+        metadata = dict(getattr(doc, "metadata", {}) or {})
+        page_content = getattr(doc, "page_content", "")
+        structured.append(
+            RetrievedDocument(
+                document_id=metadata.get("document_id") or metadata.get("source"),
+                chunk_id=metadata.get("chunk_id"),
+                title=metadata.get("title") or metadata.get("document_title"),
+                preview=_make_preview(page_content, preview_chars),
+                score=float(score) if score is not None else None,
+                metadata=metadata,
+                content=page_content if include_content else None,
+            )
+        )
+
+    serialized = _serialize(structured)
+    return serialized, structured
+
 
 @tool(response_format="content_and_artifact")
-def retrieve(query: str):
-    """Retrieve information related to a query."""
-    return _retrieve_impl(query)
+def retrieve(
+    query: str,
+    filters: Optional[Dict[str, Any]] = None,
+    limit: int = 4,
+    preview_chars: int = 280,
+):
+    """Retrieve information related to a query with optional metadata filters."""
 
-def retrieve_raw(query: str):
-    return _retrieve_impl(query)
+    return _retrieve_impl(query, filters=filters, limit=limit, preview_chars=preview_chars)
+
+
+def retrieve_raw(
+    query: str,
+    *,
+    filters: Optional[Dict[str, Any]] = None,
+    limit: int = 4,
+    preview_chars: int = 280,
+    include_content: bool = True,
+):
+    """Programmatic access to structured retrieval results."""
+
+    return _retrieve_impl(
+        query,
+        filters=filters,
+        limit=limit,
+        preview_chars=preview_chars,
+        include_content=include_content,
+    )


### PR DESCRIPTION
## Summary
- document the domain knowledge ingestion schema, UI flows, backend routes, and analytics requirements for the RAG assistant
- enhance the retrieval tooling with metadata filters, structured previews, and reusable raw accessors for curated answers

## Testing
- python -m compileall src/rag/tools.py

------
https://chatgpt.com/codex/tasks/task_e_68f82b7b03c4832fb7f05e65b38a617d