### PR TITLE
Inline simple proxy helpers

### DIFF
--- a/src/backend/core/__init__.py
+++ b/src/backend/core/__init__.py
@@ -1,0 +1,1 @@
+"""Core backend package providing authentication and proxy services."""

--- a/src/backend/core/app.py
+++ b/src/backend/core/app.py
@@ -1,0 +1,26 @@
+"""Application wiring for the backend proxy service."""
+
+from __future__ import annotations
+
+from .http import BackendApp
+from .views import rag_proxy
+
+app = BackendApp()
+
+
+@app.route("/auth/login")
+def login_endpoint(request):
+    return rag_proxy.login_endpoint(request)
+
+
+@app.route("/auth/logout")
+def logout_endpoint(request):
+    return rag_proxy.logout_endpoint(request)
+
+
+@app.route("/rag/proxy")
+def rag_proxy_endpoint(request):
+    return rag_proxy.rag_proxy_endpoint(request)
+
+
+__all__ = ["app"]

--- a/src/backend/core/auth.py
+++ b/src/backend/core/auth.py
@@ -1,0 +1,20 @@
+"""Simple credential store backed by environment defaults."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from . import settings
+
+
+@dataclass
+class User:
+    username: str
+
+
+def authenticate(username: str, password: str) -> User | None:
+    expected_user = settings.DEFAULT_USERNAME
+    expected_password = settings.DEFAULT_PASSWORD
+    if username == expected_user and password == expected_password:
+        return User(username=username)
+    return None

--- a/src/backend/core/http.py
+++ b/src/backend/core/http.py
@@ -1,0 +1,89 @@
+"""Utilities for handling lightweight HTTP-style requests and responses."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any, Callable, Dict, Optional
+
+from . import settings
+from . import session as session_backend
+
+
+@dataclass
+class Response:
+    status_code: int
+    body: Dict[str, Any]
+    cookies: Dict[str, Dict[str, Any]] = field(default_factory=dict)
+    headers: Dict[str, str] = field(default_factory=dict)
+
+    def json(self) -> Dict[str, Any]:
+        return self.body
+
+
+class RequestContext:
+    def __init__(
+        self,
+        json_body: Optional[Dict[str, Any]],
+        headers: Optional[Dict[str, str]],
+        cookies: Optional[Dict[str, str]],
+        session: session_backend.SessionData,
+    ) -> None:
+        self._json_body = json_body or {}
+        self.headers = headers or {}
+        self.cookies = cookies or {}
+        self.session = session
+
+    def json(self) -> Dict[str, Any]:
+        return dict(self._json_body)
+
+
+class BackendApp:
+    def __init__(self) -> None:
+        self._routes: Dict[str, Callable[[RequestContext], Response]] = {}
+
+    def route(self, path: str) -> Callable[[Callable[[RequestContext], Response]], Callable[[RequestContext], Response]]:
+        def decorator(func: Callable[[RequestContext], Response]) -> Callable[[RequestContext], Response]:
+            self._routes[path] = func
+            return func
+
+        return decorator
+
+    def handle(
+        self,
+        path: str,
+        json_body: Optional[Dict[str, Any]] = None,
+        headers: Optional[Dict[str, str]] = None,
+        cookies: Optional[Dict[str, str]] = None,
+    ) -> Response:
+        handler = self._routes.get(path)
+        if not handler:
+            raise ValueError(f"Unknown path: {path}")
+
+        cookie_value = (cookies or {}).get(settings.SESSION_COOKIE_NAME)
+        session = session_backend.load_from_cookie(cookie_value)
+        request = RequestContext(json_body, headers, cookies, session)
+
+        response = handler(request)
+
+        cookie_payload = session_backend.persist_session(request.session)
+        if cookie_payload == "":
+            response.cookies[settings.SESSION_COOKIE_NAME] = {
+                "value": "",
+                "path": "/",
+                "secure": settings.SESSION_COOKIE_SECURE,
+                "samesite": settings.SESSION_COOKIE_SAMESITE,
+                "expires": 0,
+            }
+        elif cookie_payload:
+            response.cookies[settings.SESSION_COOKIE_NAME] = {
+                "value": cookie_payload,
+                "path": "/",
+                "secure": settings.SESSION_COOKIE_SECURE,
+                "httponly": settings.SESSION_COOKIE_HTTPONLY,
+                "samesite": settings.SESSION_COOKIE_SAMESITE,
+            }
+
+        return response
+
+
+__all__ = ["BackendApp", "RequestContext", "Response"]

--- a/src/backend/core/session.py
+++ b/src/backend/core/session.py
@@ -1,0 +1,162 @@
+"""Lightweight signed cookie session implementation."""
+
+from __future__ import annotations
+
+import hmac
+import secrets
+import threading
+import time
+from dataclasses import dataclass, field
+from hashlib import sha256
+from typing import Dict, Optional
+
+from . import settings
+
+
+@dataclass
+class SessionData:
+    """Represents the mutable data stored for a session."""
+
+    session_id: Optional[str]
+    payload: Dict[str, str] = field(default_factory=dict)
+    created_at: float = field(default_factory=time.time)
+    dirty: bool = False
+    should_clear: bool = False
+
+    def mark_dirty(self) -> None:
+        self.dirty = True
+
+    @property
+    def is_authenticated(self) -> bool:
+        return "user" in self.payload
+
+    def require_authentication(self) -> None:
+        if not self.is_authenticated:
+            raise PermissionError("Authentication required")
+
+
+_SESSIONS: Dict[str, SessionData] = {}
+_LOCK = threading.Lock()
+
+
+def _sign(value: str) -> str:
+    signature = hmac.new(settings.SECRET_KEY.encode("utf-8"), value.encode("utf-8"), sha256)
+    return signature.hexdigest()
+
+
+def _serialize_cookie(session_id: str) -> str:
+    return f"{session_id}:{_sign(session_id)}"
+
+
+def _deserialize_cookie(cookie_value: str) -> Optional[str]:
+    if not cookie_value:
+        return None
+    try:
+        session_id, signature = cookie_value.split(":", 1)
+    except ValueError:
+        return None
+    if not hmac.compare_digest(signature, _sign(session_id)):
+        return None
+    return session_id
+
+
+def create_session(payload: Optional[Dict[str, str]] = None) -> SessionData:
+    session_id = secrets.token_hex(16)
+    data = SessionData(session_id=session_id, payload=payload or {}, created_at=time.time())
+    with _LOCK:
+        _SESSIONS[session_id] = data
+    data.mark_dirty()
+    return data
+
+
+def get_session(session_id: str) -> Optional[SessionData]:
+    with _LOCK:
+        data = _SESSIONS.get(session_id)
+    if not data:
+        return None
+    lifetime = settings.SESSION_MAX_AGE.total_seconds()
+    if data.created_at + lifetime < time.time():
+        destroy_session(session_id)
+        return None
+    return data
+
+
+def destroy_session(session_id: Optional[str]) -> None:
+    if not session_id:
+        return
+    with _LOCK:
+        _SESSIONS.pop(session_id, None)
+
+
+def load_from_cookie(cookie_value: Optional[str]) -> SessionData:
+    session_id = _deserialize_cookie(cookie_value or "")
+    if not session_id:
+        return SessionData(session_id=None)
+    data = get_session(session_id)
+    if not data:
+        return SessionData(session_id=None)
+    return SessionData(session_id=session_id, payload=dict(data.payload), created_at=data.created_at)
+
+
+def persist_session(session: SessionData) -> Optional[str]:
+    """Persist the session if it is marked as dirty.
+
+    Returns the cookie value that should be sent to the client when the session
+    has been updated.
+    """
+
+    if session.should_clear:
+        destroy_session(session.session_id)
+        return ""
+
+    if not session.dirty:
+        return None
+
+    if not session.session_id:
+        new_session = create_session(session.payload)
+        session.session_id = new_session.session_id
+        session.payload = dict(new_session.payload)
+        session.created_at = new_session.created_at
+        session.dirty = False
+        return _serialize_cookie(session.session_id)
+
+    with _LOCK:
+        _SESSIONS[session.session_id] = SessionData(
+            session_id=session.session_id,
+            payload=dict(session.payload),
+            created_at=time.time(),
+        )
+    session.dirty = False
+    return _serialize_cookie(session.session_id)
+
+
+def rotate_session(session: SessionData) -> SessionData:
+    destroy_session(session.session_id)
+    new_session = create_session(dict(session.payload))
+    return new_session
+
+
+def ensure_csrf_token(session: SessionData) -> str:
+    token = session.payload.get("csrf_token")
+    if not token:
+        token = secrets.token_urlsafe(32)
+        session.payload["csrf_token"] = token
+        session.mark_dirty()
+    return token
+
+
+def validate_csrf(session: SessionData, token: Optional[str]) -> None:
+    expected = session.payload.get("csrf_token")
+    if not expected or not token or not hmac.compare_digest(expected, token):
+        raise ValueError("Invalid CSRF token")
+
+
+def login_user(session: SessionData, username: str) -> None:
+    session.payload["user"] = username
+    session.mark_dirty()
+
+
+def logout_user(session: SessionData) -> None:
+    session.payload.clear()
+    session.should_clear = True
+

--- a/src/backend/core/settings.py
+++ b/src/backend/core/settings.py
@@ -1,0 +1,24 @@
+"""Runtime settings for the backend proxy service."""
+
+from __future__ import annotations
+
+import os
+from datetime import timedelta
+
+SECRET_KEY = os.environ.get("BACKEND_SECRET_KEY", "development-secret-key")
+SESSION_COOKIE_NAME = "sessionid"
+SESSION_COOKIE_SECURE = True
+SESSION_COOKIE_HTTPONLY = True
+SESSION_COOKIE_SAMESITE = "strict"
+SESSION_MAX_AGE = timedelta(hours=1)
+
+CSRF_COOKIE_NAME = "csrftoken"
+CSRF_COOKIE_SECURE = True
+CSRF_COOKIE_SAMESITE = "strict"
+CSRF_HEADER_NAME = "X-CSRFToken"
+
+DEFAULT_USERNAME = os.environ.get("BACKEND_USERNAME", "admin")
+DEFAULT_PASSWORD = os.environ.get("BACKEND_PASSWORD", "change-me")
+
+RAG_SERVICE_URL = os.environ.get("RAG_SERVICE_URL", "http://localhost:9000/chat")
+RAG_SERVICE_API_KEY = os.environ.get("RAG_SERVICE_API_KEY", "test-api-key")

--- a/src/backend/core/views/__init__.py
+++ b/src/backend/core/views/__init__.py
@@ -1,0 +1,1 @@
+"""View layer for the backend stack."""

--- a/src/backend/core/views/rag_proxy.py
+++ b/src/backend/core/views/rag_proxy.py
@@ -1,0 +1,88 @@
+"""Endpoints for authenticating users and proxying chat requests."""
+
+from __future__ import annotations
+
+import json
+import urllib.request
+from http import HTTPStatus
+from typing import Any, Dict
+
+from .. import auth, settings
+from ..session import ensure_csrf_token, login_user, logout_user, validate_csrf
+from ..http import RequestContext, Response
+
+
+def login_endpoint(request: RequestContext) -> Response:
+    payload = request.json()
+    username = payload.get("username")
+    password = payload.get("password")
+    if not username or not password:
+        return Response(status_code=HTTPStatus.BAD_REQUEST, body={"detail": "Missing credentials"})
+
+    user = auth.authenticate(username, password)
+    if not user:
+        return Response(status_code=HTTPStatus.UNAUTHORIZED, body={"detail": "Invalid credentials"})
+
+    session = request.session
+    login_user(session, user.username)
+    csrf_token = ensure_csrf_token(session)
+
+    response = Response(status_code=HTTPStatus.OK, body={"status": "ok", "user": user.username})
+    response.cookies[settings.CSRF_COOKIE_NAME] = {
+        "value": csrf_token,
+        "secure": settings.CSRF_COOKIE_SECURE,
+        "httponly": False,
+        "samesite": settings.CSRF_COOKIE_SAMESITE,
+        "path": "/",
+    }
+    return response
+
+
+def logout_endpoint(request: RequestContext) -> Response:
+    session = request.session
+    if session.is_authenticated:
+        logout_user(session)
+    response = Response(status_code=HTTPStatus.OK, body={"status": "ok"})
+    response.cookies[settings.CSRF_COOKIE_NAME] = {
+        "value": "",
+        "secure": settings.CSRF_COOKIE_SECURE,
+        "samesite": settings.CSRF_COOKIE_SAMESITE,
+        "path": "/",
+        "expires": 0,
+    }
+    return response
+
+
+def rag_proxy_endpoint(request: RequestContext) -> Response:
+    session = request.session
+    if not session.is_authenticated:
+        return Response(status_code=HTTPStatus.FORBIDDEN, body={"detail": "Login required"})
+
+    csrf_header = request.headers.get(settings.CSRF_HEADER_NAME)
+    try:
+        validate_csrf(session, csrf_header)
+    except ValueError as exc:
+        return Response(status_code=HTTPStatus.FORBIDDEN, body={"detail": str(exc)})
+
+    payload = request.json()
+    headers = {"Content-Type": "application/json"}
+    if settings.RAG_SERVICE_API_KEY:
+        headers["Authorization"] = f"Bearer {settings.RAG_SERVICE_API_KEY}"
+    proxy_request = urllib.request.Request(
+        settings.RAG_SERVICE_URL,
+        data=json.dumps(payload).encode("utf-8"),
+        headers=headers,
+        method="POST",
+    )
+    try:
+        with urllib.request.urlopen(proxy_request) as result:
+            body = result.read().decode("utf-8")
+            status_code = result.status
+            content_type = result.headers.get("Content-Type", "application/json")
+    except Exception as exc:  # pragma: no cover
+        return Response(status_code=HTTPStatus.BAD_GATEWAY, body={"detail": str(exc)})
+
+    data = json.loads(body) if body else {}
+    response = Response(status_code=status_code, body=data)
+    response.headers["Content-Type"] = content_type
+    return response

--- a/src/backend/manage.py
+++ b/src/backend/manage.py
@@ -1,0 +1,32 @@
+#!/usr/bin/env python3
+"""Minimal management entry point for the backend stack.
+
+This stub mirrors the layout produced by ``django-admin startproject`` so that
+other tooling can discover the backend package.  In this offline environment we
+bootstrap the FastAPI application that powers the proxy and authentication
+logic instead of invoking Django's management commands.
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+
+DEFAULT_SETTINGS_MODULE = "core.settings"
+
+
+def main() -> None:
+    os.environ.setdefault("BACKEND_SETTINGS_MODULE", DEFAULT_SETTINGS_MODULE)
+    if len(sys.argv) > 1:
+        command = " ".join(sys.argv[1:])
+    else:
+        command = "(none)"
+    message = (
+        "Management command support is not available in this environment. "
+        "Requested command: %s."
+    )
+    print(message % command)
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/backend/test_backend_integration.py
+++ b/tests/backend/test_backend_integration.py
@@ -1,0 +1,117 @@
+from __future__ import annotations
+
+import json
+import os
+from http import HTTPStatus
+from pathlib import Path
+from typing import Dict
+from unittest import mock
+
+import sys
+
+ROOT = Path(__file__).resolve().parents[2]
+SRC = ROOT / "src"
+if str(SRC) not in sys.path:
+    sys.path.insert(0, str(SRC))
+
+# Configure runtime before importing the application so that settings resolve to
+# predictable values for the tests.
+os.environ.setdefault("BACKEND_USERNAME", "admin")
+os.environ.setdefault("BACKEND_PASSWORD", "s3cret")
+os.environ.setdefault("RAG_SERVICE_URL", "http://rag-service.local/chat")
+os.environ.setdefault("RAG_SERVICE_API_KEY", "token-123")
+
+from backend.core import settings
+from backend.core.app import app
+from backend.core.http import BackendApp
+
+
+class BackendClient:
+    def __init__(self, backend: BackendApp):
+        self.backend = backend
+        self.cookies: Dict[str, str] = {}
+
+    def post(self, path: str, json_body: Dict[str, str], headers: Dict[str, str] | None = None):
+        response = self.backend.handle(path, json_body=json_body, headers=headers, cookies=self.cookies)
+        for name, meta in response.cookies.items():
+            value = meta.get("value", "")
+            if not value:
+                self.cookies.pop(name, None)
+            else:
+                self.cookies[name] = value
+        return response
+
+
+def _client() -> BackendClient:
+    return BackendClient(app)
+
+
+def test_login_sets_session_and_csrf_cookie():
+    client = _client()
+
+    response = client.post("/auth/login", json_body={"username": "admin", "password": "s3cret"})
+
+    assert response.status_code == HTTPStatus.OK
+    assert response.json()["status"] == "ok"
+
+    session_cookie = response.cookies[settings.SESSION_COOKIE_NAME]["value"]
+    csrf_cookie = response.cookies[settings.CSRF_COOKIE_NAME]["value"]
+
+    assert session_cookie
+    assert csrf_cookie
+
+
+def test_proxy_requires_login():
+    client = _client()
+    response = client.post("/rag/proxy", json_body={"message": "hi"})
+    assert response.status_code == HTTPStatus.FORBIDDEN
+
+
+def test_proxy_with_session_and_csrf():
+    client = _client()
+
+    login_response = client.post("/auth/login", json_body={"username": "admin", "password": "s3cret"})
+    csrf_cookie = login_response.cookies[settings.CSRF_COOKIE_NAME]["value"]
+
+    fake_response = mock.MagicMock()
+    fake_response.read.return_value = json.dumps({"reply": "hello"}).encode("utf-8")
+    fake_response.status = HTTPStatus.OK
+    fake_response.headers = {"Content-Type": "application/json"}
+
+    class _Context:
+        def __enter__(self):
+            return fake_response
+
+        def __exit__(self, exc_type, exc, tb):
+            return False
+
+    def fake_urlopen(request_obj):
+        assert request_obj.full_url == os.environ["RAG_SERVICE_URL"]
+        assert json.loads(request_obj.data.decode("utf-8")) == {"message": "ping"}
+        assert request_obj.get_header("Authorization") == "Bearer token-123"
+        return _Context()
+
+    with mock.patch("backend.core.views.rag_proxy.urllib.request.urlopen", fake_urlopen):
+        response = client.post(
+            "/rag/proxy",
+            json_body={"message": "ping"},
+            headers={settings.CSRF_HEADER_NAME: csrf_cookie},
+        )
+
+    assert response.status_code == HTTPStatus.OK
+    assert response.json() == {"reply": "hello"}
+
+
+def test_logout_clears_session():
+    client = _client()
+    login_response = client.post("/auth/login", json_body={"username": "admin", "password": "s3cret"})
+    csrf_cookie = login_response.cookies[settings.CSRF_COOKIE_NAME]["value"]
+
+    response = client.post(
+        "/auth/logout",
+        json_body={},
+        headers={settings.CSRF_HEADER_NAME: csrf_cookie},
+    )
+
+    assert response.status_code == HTTPStatus.OK
+    assert response.cookies[settings.SESSION_COOKIE_NAME]["value"] == ""


### PR DESCRIPTION
## Summary
- remove trivial helper functions from the RAG proxy view and inline their logic for clarity
- construct proxy responses and forwarded requests directly where needed while preserving behavior

## Testing
- pytest tests/backend

------
https://chatgpt.com/codex/tasks/task_e_68f83435544c832f811f994358392885